### PR TITLE
Improve installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ Perform these steps to install WyckoffDiff and its dependencies.
 
     **Alternatively**, if your system Python version is recent enough, you can instead use a Python venv:
     ```
-    mkdir -p data/deps/venv
+    mkdir -p data/deps
     python3 -m venv data/deps/venv
     source data/deps/venv/bin/activate
     ```


### PR DESCRIPTION
After having gone through the installation a couple of times, these instructions fixes a few things missing and seem safer in terms of locked-in versions and order of installation.