### PR TITLE
Improve checksum error message.

### DIFF
--- a/wyckoff_generation/datasets/dataset.py
+++ b/wyckoff_generation/datasets/dataset.py
@@ -274,7 +274,7 @@ class WyckoffDataset(InMemoryDataset):
 
         if not compare_hash(zipped_file, self.hash_dict[self.split]):
             raise ValueError(
-                f"Invalid hash for downloaded file: {self.suffix} {self.split} set. Please remove"
+                f"Invalid hash for downloaded file: {self.suffix} {self.split} set. To redownload, remove the file: {zipped_file}"
             )
 
         decompress_bz2_file(


### PR DESCRIPTION
The error message after getting a checksum error wasn't to friendly about what file to remove. This fixes that issue.