### PR TITLE
ICML bibtex, and typo in link to license

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,15 @@ If you have any questions or issues, please feel free to open an issue, or send 
 ## Citation
 If you have used this code, please cite the WyckoffDiff paper
 ```
-@misc{kelvinius2025wyckoffdiff,
+@inproceedings{
+      kelvinius2025wyckoffdiff,
       title={WyckoffDiff -- A Generative Diffusion Model for Crystal Symmetry},
-      author={Filip Ekström Kelvinius and Oskar B. Andersson and Abhijith S. Parackal and Dong Qian and Rickard Armiento and Fredrik Lindsten},
+      author={Filip Ekstr{\"o}m Kelvinius and Oskar B. Andersson and Abhijith S Parackal and Dong Qian and Rickard Armiento and Fredrik Lindsten},
+      booktitle={Forty-second International Conference on Machine Learning},
       year={2025},
-      eprint={2502.06485},
-      archivePrefix={arXiv},
-      primaryClass={cond-mat.mtrl-sci},
-      url={https://arxiv.org/abs/2502.06485},
+      url={https://openreview.net/forum?id=OHPBPveXdg}
 }
 ```
 
 ## License
-This code is primarily licensed with the MIT License available in the file [`LICENSE`](LICENSE). The parts under [`wyckoff_generation/models/d3pm`](wyckoff_generation/models/d3pm) are based on the official public D3PM implementation <https://github.com/google-research/google-research/tree/master/d3pm> and therefore licensed separately under the Apache 2.0 license available at [`wyckoff_generation/models/d3pm/LICENSE`](wyckoff_generation/models/d3pm/LICENSE).
+This code is primarily licensed with the MIT License available in the file [`LICENSE`](LICENSE). The parts under [`wyckoff_generation/models/d3pm`](wyckoff_generation/models/d3pm) are based on the official public D3PM implementation <https://github.com/google-research/google-research/tree/master/d3pm> and therefore licensed separately under the Apache 2.0 license available at [`wyckoff_generation/models/d3pm/LICENSE.txt`](wyckoff_generation/models/d3pm/LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WyckoffDiff
 ![](assets/wyckoffdiff_graphical_abstract.png)
 
-This is the offical public repository for the paper [_WyckoffDiff -- A Generative Diffusion Model for Crystal Symmetry_](https://arxiv.org/abs/2502.06485) by Filip Ekström Kelvinius, Oskar B. Andersson, Abhijith S. Parackal, Dong Qian, Rickard Armiento, and Fredrik Lindsten. See [Citation](#citation) for how to cite this work.
+This is the offical public repository for the ICML 2025 paper [_WyckoffDiff -- A Generative Diffusion Model for Crystal Symmetry_](https://arxiv.org/abs/2502.06485) by Filip Ekström Kelvinius, Oskar B. Andersson, Abhijith S. Parackal, Dong Qian, Rickard Armiento, and Fredrik Lindsten. See [Citation](#citation) for how to cite this work.
 
 ## Data
 The code already supports the dataset used in the paper (WBM), in addition to MP20 and Carbon24. Download is automatic, and using the codebase **does not require any manual download**. Please see the [data README](data/README.md) for more information on the data.


### PR DESCRIPTION
Changed the citation bibtex from arxiv to ICML, taken from Openreview. Also fixed a typo in the README: the link to the d3pm license