### PR TITLE
Update installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,11 +26,6 @@ Perform these steps to install WyckoffDiff and its dependencies.
     pip install -e .
     ```
 
-1. Install [Aviary](https://github.com/CompRhys/aviary) by
-    ```
-    pip install -U git+https://github.com/CompRhys/aviary@v1.1.1
-    ```
-
 1. Install pre-commit hooks by
     ```
     pre-commit install

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ Perform these steps to install WyckoffDiff and its dependencies.
     cd wyckoffdiff
     ```
 
-2. Create a conda environment called ```wyckoffdiff``` with Python 3.12 and activate it using
+1. Create a conda environment called ```wyckoffdiff``` with Python 3.12 and activate it using
     ```
     conda create -n wyckoffdiff python=3.12
     conda activate wyckoffdiff
@@ -21,24 +21,17 @@ Perform these steps to install WyckoffDiff and its dependencies.
     source data/deps/venv/bin/activate
     ```
 
-3. Install [NumPy](https://numpy.org/), [PyTorch](https://pytorch.org/), and [PyTorch Scatter](https://pypi.org/project/torch-scatter/) by
-    ```
-    pip install numpy==1.26.4 torch==2.3.0 torch-scatter -f https://data.pyg.org/whl/torch-2.3.0+{COMPUTE_PLATFORM}.html
-    ```
-    where `{COMPUTE_PLATFORM}` should be `cu118`, `cu121` or `cpu`.
-    For CUDA, the version of your installed driver can be seen in the output of `nvidia-smi`, and it may be a good idea to pick the highest version of 1.18 or 1.21 that is lower or equal to the version supported by the driver.
-
-4. Install [Aviary](https://github.com/CompRhys/aviary) by
-    ```
-    pip install -U git+https://github.com/CompRhys/aviary@v1.1.1
-    ```
-
-5. Install wyckoffdiff as a package with its dependencies by
+1. Install ```wyckoff_generation``` as a package with its dependencies by
     ```
     pip install -e .
     ```
 
-6. Install pre-commit hooks by
+1. Install [Aviary](https://github.com/CompRhys/aviary) by
+    ```
+    pip install -U git+https://github.com/CompRhys/aviary@v1.1.1
+    ```
+
+1. Install pre-commit hooks by
     ```
     pre-commit install
     ```

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "torch_geometric==2.5.3",
         "tqdm",
         "numpy==1.26.4",
+        'Aviary @ git+https://github.com/CompRhys/aviary@v1.1.1',
         "matplotlib",
         "scikit-learn",
         "pandas",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "torch==2.3.0",
         "torch_geometric==2.5.3",
         "tqdm",
-        "numpy",
+        "numpy==1.26.4",
         "matplotlib",
         "scikit-learn",
         "pandas",


### PR DESCRIPTION
Simplifies instructions in INSTALL.md by removing the step where torch, numpy and torch-scatter were installed. This is done by:
* Removing dependency on torch-scatter completely (as we are using Aviary 1.1.1)
* Adding explicit version to numpy in setup.py

torch already had the correct version in setup.py

Also changed the order of the steps: first install wyckoff_generation, then install Aviary. 